### PR TITLE
delete main.js script

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -94,16 +94,6 @@
             }
         });
 
-        searchWrap.on('click',  function(e) {
-            if( !$(e.target).is('.search-field') ) {
-                closeSearch.trigger('click');
-            }
-        });
-            
-        searchField.on('click', function(e){
-            e.stopPropagation();
-        });
-            
         searchField.attr({placeholder: 'Type Keywords', autocomplete: 'off'});
 
     };


### PR DESCRIPTION
# Google Programmable Searchのタブの修正
README.mdにある『Google Programmable Searchについて』を修正しました。

main.js内の96行以下
```
searchWrap.on('click',  function(e) {
    if( !$(e.target).is('.search-field') ) {
        closeSearch.trigger('click');
    }
});
    
searchField.on('click', function(e){
    e.stopPropagation();
});
```
を削除しました。

タブでの検索
https://gyazo.com/832d56023ab475b735133fe6843de493

タブを閉じる際
![demo](https://gyazo.com/e8a2ada6dc5c3330e8a76a0729c25a55/raw)